### PR TITLE
refactor agent

### DIFF
--- a/lib/kudago_client/entities/agent.rb
+++ b/lib/kudago_client/entities/agent.rb
@@ -20,6 +20,8 @@ module KudagoClient
       # rank - рейтинг объекта
       # participations - список участий агента
 
+      Participation = Struct.new(:role, :event)
+
       attr_reader :lang, :id, :title, :slug, :favorites_count, :comments_count, :description, :body_text,
         :site_url, :disable_comments, :ctype, :images, :agent_type, :rank, :participations, :text_format, :is_stub
 
@@ -39,7 +41,6 @@ module KudagoClient
         @disable_comments = disable_comments
         @favorites_count = favorites_count
         @is_stub = is_stub
-        @participations = participations # participant entity ???
         @rank = rank
         @site_url = site_url
         @slug = slug
@@ -48,6 +49,12 @@ module KudagoClient
 
         @images = images&.map do |image|
           KudagoClient::Entities::Image.new(image: image[:image], thumbnails: image[:thumbnails], source: image[:source])
+        end
+        @participations = participations&.map do |participation|
+          Participation.new(
+            Role.new(**participation[:role], lang: lang),
+            Event.new(**participation[:item], lang: lang)
+          )
         end
       end
     end

--- a/lib/kudago_client/entities/agent.rb
+++ b/lib/kudago_client/entities/agent.rb
@@ -53,7 +53,7 @@ module KudagoClient
         @participations = participations&.map do |participation|
           Participation.new(
             Role.new(**participation[:role], lang: lang),
-            Event.new(**participation[:item], lang: lang)
+            (participation[:item][:ctype] == "event") ? Event.new(**participation[:item].except(:ctype), lang: lang) : nil
           )
         end
       end


### PR DESCRIPTION
Refactored the `Agent` entity to introduce a structured representation for agent participations.

Previously, agent participations were stored as raw data. This change introduces a new `Participation` struct, which encapsulates an agent's `role` and the associated `event` (item).

Key changes include:
*   Defined a `Participation` struct within the `Agent` class to hold `role` and `event` data.
*   Modified the `Agent` initializer to parse raw `participations` data into a collection of `Participation` objects.
*   Each `Participation` object now contains a `Role` entity (initialized from `participation[:role]`) and an `Event` entity (initialized from `participation[:item]`), ensuring a more structured and type-safe representation of an agent's involvement.