### PR TITLE
add methods to get another page

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ client.events_of_the_day({}) # KudagoClient::EntitiesList::EventList
 client.lists({}) # KudagoClient::EntitiesList::ListList
 client.list_comments(list_id, {}) # KudagoClient::EntitiesList::CommentList
 client.search(query, {}) # KudagoClient::EntitiesList::MultipleList
+
+# get another page of list
+client.next_page(list, {})
+client.previous_page(list, {})
 ```
 
 
@@ -93,6 +97,11 @@ end
 
 ## Development
 
+You can contribute to this gem :)
+
+Just fork the repo and then make PR
+
+I wrote a simple [To Do list](./to_do.md)
 
 ## Contributing
 

--- a/lib/kudago_client/client.rb
+++ b/lib/kudago_client/client.rb
@@ -13,6 +13,7 @@ require_relative "requests/event_request"
 require_relative "requests/event_of_the_day_request"
 require_relative "requests/list_request"
 require_relative "requests/search_request"
+require_relative "requests/base_request"
 
 require_relative "entities/location"
 require_relative "entities/agent"
@@ -52,173 +53,189 @@ module KudagoClient
       @lang = lang
     end
 
+    # PAGE METHODS
+
+    def next_page(list, params = {})
+      return nil if list.next_url.nil?
+
+      res = Requests::BaseRequest.get(list.next_url, params)
+      list.class.new(**res.data, lang: entity_lang(params))
+    end
+
+    def previous_page(list, params = {})
+      return nil if list.previous_url.nil?
+
+      res = Requests::BaseRequest.get(list.previous_url, params)
+      list.class.new(**res.data, lang: entity_lang(params))
+    end
+
     # ENTITY METHODS
 
     def agent(agent_id, params = {})
       res = Requests::AgentRequest.find(agent_id, params)
-      KudagoClient::Entities::Agent.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::Agent.new(**res.data, lang: entity_lang(params))
     end
 
     def location(slug, params = {})
       res = Requests::LocationRequest.find(slug, params)
-      KudagoClient::Entities::Location.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::Location.new(**res.data, lang: entity_lang(params))
     end
 
     def role(role_id, params = {})
       res = Requests::RoleRequest.find(role_id, params)
-      KudagoClient::Entities::Role.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::Role.new(**res.data, lang: entity_lang(params))
     end
 
     def event_category(event_category_id, params = {})
       res = Requests::EventCategoryRequest.find(event_category_id, params)
-      KudagoClient::Entities::EventCategory.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::EventCategory.new(**res.data, lang: entity_lang(params))
     end
 
     def place_category(place_category_id, params = {})
       res = Requests::PlaceCategoryRequest.find(place_category_id, params)
-      KudagoClient::Entities::PlaceCategory.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::PlaceCategory.new(**res.data, lang: entity_lang(params))
     end
 
     def movie(movie_id, params = {})
       res = Requests::MovieRequest.find(movie_id, params)
-      KudagoClient::Entities::Movie.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::Movie.new(**res.data, lang: entity_lang(params))
     end
 
     def showing(showing_id, params = {})
       res = Requests::MovieShowingRequest.find(showing_id, params)
-      KudagoClient::Entities::MovieShowing.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::MovieShowing.new(**res.data, lang: entity_lang(params))
     end
 
     def place(place_id, params = {})
       res = Requests::PlaceRequest.find(place_id, params)
-      KudagoClient::Entities::Place.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::Place.new(**res.data, lang: entity_lang(params))
     end
 
     def piece_news(news_id, params = {})
       res = Requests::NewsRequest.find(news_id, params)
-      KudagoClient::Entities::News.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::News.new(**res.data, lang: entity_lang(params))
     end
 
     def news_comment(news_id, comment_id, params = {})
       res = Requests::NewsRequest.comment(news_id, comment_id, params)
-      KudagoClient::Entities::Comment.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::Comment.new(**res.data, lang: entity_lang(params))
     end
 
     def event(event_id, params = {})
       res = Requests::EventRequest.find(event_id, params)
-      KudagoClient::Entities::Event.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::Event.new(**res.data, lang: entity_lang(params))
     end
 
     def event_comment(event_id, comment_id, params = {})
       res = Requests::EventRequest.comment(event_id, comment_id, params)
-      KudagoClient::Entities::Comment.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::Comment.new(**res.data, lang: entity_lang(params))
     end
 
     def list(list_id, params = {})
       res = Requests::ListRequest.find(list_id, params)
-      KudagoClient::Entities::List.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::List.new(**res.data, lang: entity_lang(params))
     end
 
     def list_comment(list_id, comment_id, params = {})
       res = Requests::ListRequest.comment(list_id, comment_id, params)
-      KudagoClient::Entities::Comment.new(**res, lang: entity_lang(params))
+      KudagoClient::Entities::Comment.new(**res.data, lang: entity_lang(params))
     end
 
     # LIST METHODS
 
     def agents(params = {})
       res = Requests::AgentRequest.list(params)
-      KudagoClient::EntitiesList::AgentList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::AgentList.new(**res.data, lang: entity_lang(params))
     end
 
     def locations(params = {})
       res = Requests::LocationRequest.list(params)
-      KudagoClient::EntitiesList::LocationList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::LocationList.new(**res.data, lang: entity_lang(params))
     end
 
     def roles(params = {})
       res = Requests::RoleRequest.list(params)
-      KudagoClient::EntitiesList::RoleList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::RoleList.new(**res.data, lang: entity_lang(params))
     end
 
     def event_categories(params = {})
       res = Requests::EventCategoryRequest.list(params)
-      KudagoClient::EntitiesList::EventCategoriesList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::EventCategoriesList.new(**res.data, lang: entity_lang(params))
     end
 
     def place_categories(params = {})
       res = Requests::PlaceCategoryRequest.list(params)
-      KudagoClient::EntitiesList::PlaceCategoriesList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::PlaceCategoriesList.new(**res.data, lang: entity_lang(params))
     end
 
     def movies(params = {})
       res = Requests::MovieRequest.list(params)
-      KudagoClient::EntitiesList::MovieList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::MovieList.new(**res.data, lang: entity_lang(params))
     end
 
     def movie_comments(movie_id, params = {})
       res = Requests::MovieRequest.comments(movie_id, params)
-      KudagoClient::EntitiesList::CommentList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::CommentList.new(**res.data, lang: entity_lang(params))
     end
 
     def showings(params = {})
       res = Requests::MovieShowingRequest.list(params)
-      KudagoClient::EntitiesList::MovieShowingList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::MovieShowingList.new(**res.data, lang: entity_lang(params))
     end
 
     def movie_showings(movie_id, params = {})
       res = Requests::MovieRequest.showings(movie_id, params)
-      KudagoClient::EntitiesList::MovieShowingList.new(**res, item_params: {movie: {id: movie_id}}, lang: entity_lang(params))
+      KudagoClient::EntitiesList::MovieShowingList.new(**res.data, item_params: {movie: {id: movie_id}}, lang: entity_lang(params))
     end
 
     def places(params = {})
       res = Requests::PlaceRequest.list(params)
-      KudagoClient::EntitiesList::PlaceList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::PlaceList.new(**res.data, lang: entity_lang(params))
     end
 
     def place_comments(place_id, params = {})
       res = Requests::PlaceRequest.comments(place_id, params)
-      KudagoClient::EntitiesList::CommentList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::CommentList.new(**res.data, lang: entity_lang(params))
     end
 
     def news(params = {})
       res = Requests::NewsRequest.list(params)
-      KudagoClient::EntitiesList::NewsList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::NewsList.new(**res.data, lang: entity_lang(params))
     end
 
     def news_comments(news_id, params = {})
       res = Requests::NewsRequest.comments(news_id, params)
-      KudagoClient::EntitiesList::CommentList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::CommentList.new(**res.data, lang: entity_lang(params))
     end
 
     def events(params = {})
       res = Requests::EventRequest.list(params)
-      KudagoClient::EntitiesList::EventList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::EventList.new(**res.data, lang: entity_lang(params))
     end
 
     def event_comments(event_id, params = {})
       res = Requests::EventRequest.comments(event_id, params)
-      KudagoClient::EntitiesList::CommentList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::CommentList.new(**res.data, lang: entity_lang(params))
     end
 
     def events_of_the_day(params = {})
       res = Requests::EventOfTheDayRequest.list(params)
-      KudagoClient::EntitiesList::EventList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::EventList.new(**res.data, lang: entity_lang(params))
     end
 
     def lists(params = {})
       res = Requests::ListRequest.list(params)
-      KudagoClient::EntitiesList::ListList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::ListList.new(**res.data, lang: entity_lang(params))
     end
 
     def list_comments(list_id, params = {})
       res = Requests::ListRequest.comments(list_id, params)
-      KudagoClient::EntitiesList::CommentList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::CommentList.new(**res.data, lang: entity_lang(params))
     end
 
     def search(query, params = {})
       res = Requests::SearchRequest.search(query, params)
-      KudagoClient::EntitiesList::MultipleList.new(**res, lang: entity_lang(params))
+      KudagoClient::EntitiesList::MultipleList.new(**res.data, lang: entity_lang(params))
     end
 
     private

--- a/lib/kudago_client/entities_list/base_list.rb
+++ b/lib/kudago_client/entities_list/base_list.rb
@@ -5,8 +5,8 @@ module KudagoClient
 
       def initialize(count:, next_url:, previous_url:, results:, lang: "ru", item_params: {})
         @count = count
-        @next = next_url
-        @previous = previous_url
+        @next_url = next_url
+        @previous_url = previous_url
         @lang = lang
 
         @items = results.map do |item|

--- a/lib/kudago_client/requests/agent_request.rb
+++ b/lib/kudago_client/requests/agent_request.rb
@@ -9,7 +9,7 @@ module KudagoClient
 
       def self.list(params = {})
         params.slice!(:lang, :text_format, :ids, :fields, :agent_type, :expand, :tags)
-        parse_response_urls(get(PATH, params))
+        get(PATH, params)
       end
 
       def self.find(agent_id, params = {})

--- a/lib/kudago_client/requests/base_request.rb
+++ b/lib/kudago_client/requests/base_request.rb
@@ -10,7 +10,7 @@ module KudagoClient
       def self.get(path, params = {})
         response = connection.get(path, params)
 
-        if response.success? && response.body.present?
+        if response.success?
           Response.new(response.body)
         else
           message = response.body.is_a?(String) ? [response.reason_phrase, response.status].join(" ") : response.body[:detail]

--- a/lib/kudago_client/requests/base_request.rb
+++ b/lib/kudago_client/requests/base_request.rb
@@ -10,7 +10,7 @@ module KudagoClient
       def self.get(path, params = {})
         response = connection.get(path, params)
 
-        if response.success?
+        if response.success? && response.body.present?
           Response.new(response.body)
         else
           message = response.body.is_a?(String) ? [response.reason_phrase, response.status].join(" ") : response.body[:detail]

--- a/lib/kudago_client/requests/base_request.rb
+++ b/lib/kudago_client/requests/base_request.rb
@@ -1,5 +1,6 @@
 require_relative "../connection"
 require_relative "../error"
+require_relative "../response"
 
 require "active_support/core_ext/hash"
 
@@ -10,7 +11,7 @@ module KudagoClient
         response = connection.get(path, params)
 
         if response.success?
-          response.body
+          Response.new(response.body)
         else
           message = response.body.is_a?(String) ? [response.reason_phrase, response.status].join(" ") : response.body[:detail]
           raise KudagoClient::Error.new(message:, status: response.status, reason: response.reason_phrase)
@@ -21,13 +22,6 @@ module KudagoClient
 
       def self.connection
         @@connection ||= Connection.connection
-      end
-
-      def self.parse_response_urls(res)
-        res[:next_url] = res.delete :next
-        res[:previous_url] = res.delete :previous
-
-        res
       end
     end
   end

--- a/lib/kudago_client/requests/event_category_request.rb
+++ b/lib/kudago_client/requests/event_category_request.rb
@@ -9,9 +9,7 @@ module KudagoClient
 
       def self.list(params = {})
         params.slice!(:lang, :fields, :order_by)
-        res = get(PATH, params)
-
-        parse_response_urls({results: res, count: res.size})
+        get(PATH, params)
       end
 
       def self.find(event_category_id, params = {})

--- a/lib/kudago_client/requests/event_of_the_day_request.rb
+++ b/lib/kudago_client/requests/event_of_the_day_request.rb
@@ -12,10 +12,16 @@ module KudagoClient
         params.slice!(:lang, :page, :page_size, :fields, :expand, :text_format, :location, :date)
         res = get(PATH, params)
 
-        # looks bad :(
-        res.data[:results] = res.data[:results].map do |event_data|
-          parse_event_data(event_data)
-        end
+        # looks bad a little :(
+        results = res.data[:results]
+        res.data[:results] =
+          if results.nil?
+            []
+          else
+            res.data[:results] = res.data[:results].map do |event_data|
+              parse_event_data(event_data)
+            end
+          end
 
         res
       end

--- a/lib/kudago_client/requests/event_of_the_day_request.rb
+++ b/lib/kudago_client/requests/event_of_the_day_request.rb
@@ -12,11 +12,12 @@ module KudagoClient
         params.slice!(:lang, :page, :page_size, :fields, :expand, :text_format, :location, :date)
         res = get(PATH, params)
 
-        res[:results] = res[:results].map do |event_data|
+        # looks bad :(
+        res.data[:results] = res.data[:results].map do |event_data|
           parse_event_data(event_data)
         end
 
-        parse_response_urls(res)
+        res
       end
 
       private_class_method

--- a/lib/kudago_client/requests/event_request.rb
+++ b/lib/kudago_client/requests/event_request.rb
@@ -11,7 +11,7 @@ module KudagoClient
         params.slice!(:lang, :page, :page_size, :fields, :expand, :order_by, :text_format, :ids, :location,
           :actual_since, :actual_until, :place_id, :parent_id, :is_free, :categories, :tags, :lon, :lat, :radius)
 
-        parse_response_urls(get(PATH, params))
+        get(PATH, params)
       end
 
       def self.find(event_id, params = {})
@@ -21,7 +21,7 @@ module KudagoClient
 
       def self.comments(event_id, params = {})
         params.slice!(:lang, :page, :page_size, :fields, :order_by, :ids)
-        parse_response_urls(get("#{PATH}#{event_id}/comments/", params))
+        get("#{PATH}#{event_id}/comments/", params)
       end
 
       def self.comment(event_id, comment_id, params = {})

--- a/lib/kudago_client/requests/list_request.rb
+++ b/lib/kudago_client/requests/list_request.rb
@@ -9,7 +9,7 @@ module KudagoClient
 
       def self.list(params = {})
         params.slice!(:lang, :page, :page_size, :fields, :expand, :order_by, :text_format, :ids, :tags, :location)
-        parse_response_urls(get(PATH, params))
+        get(PATH, params)
       end
 
       def self.find(list_id, params = {})
@@ -19,7 +19,7 @@ module KudagoClient
 
       def self.comments(list_id, params = {})
         params.slice!(:lang, :page, :page_size, :fields, :order_by, :ids)
-        parse_response_urls(get("#{PATH}#{list_id}/comments/", params))
+        get("#{PATH}#{list_id}/comments/", params)
       end
 
       def self.comment(list_id, comment_id, params = {})

--- a/lib/kudago_client/requests/location_request.rb
+++ b/lib/kudago_client/requests/location_request.rb
@@ -9,9 +9,7 @@ module KudagoClient
 
       def self.list(params = {})
         params.slice!(:lang, :fields, :order_by)
-        res = get(PATH, params)
-
-        parse_response_urls({results: res, count: res.size})
+        get(PATH, params)
       end
 
       def self.find(slug, params = {})

--- a/lib/kudago_client/requests/movie_request.rb
+++ b/lib/kudago_client/requests/movie_request.rb
@@ -11,7 +11,7 @@ module KudagoClient
         params.slice!(:lang, :page, :page_size, :fields, :expand, :order_by, :text_format, :ids, :tags,
           :location, :premiering_in_location, :is_free, :place_id, :actual_since, :actual_until)
 
-        parse_response_urls(get(PATH, params))
+        get(PATH, params)
       end
 
       def self.find(movie_id, params = {})
@@ -23,12 +23,12 @@ module KudagoClient
         params.slice!(:lang, :page, :page_size, :fields, :expand, :order_by, :location,
           :actual_since, :actual_until, :place, :is_free)
 
-        parse_response_urls(get("#{PATH}#{movie_id}/showings/", params))
+        get("#{PATH}#{movie_id}/showings/", params)
       end
 
       def self.comments(movie_id, params = {})
         params.slice!(:lang, :page, :page_size, :fields, :order_by, :ids)
-        parse_response_urls(get("#{PATH}#{movie_id}/comments/", params))
+        get("#{PATH}#{movie_id}/comments/", params)
       end
     end
   end

--- a/lib/kudago_client/requests/movie_showing_request.rb
+++ b/lib/kudago_client/requests/movie_showing_request.rb
@@ -11,7 +11,7 @@ module KudagoClient
         params.slice!(:lang, :page, :page_size, :fields, :expand, :order_by, :ids,
           :location, :actual_since, :actual_until, :place_id, :is_free)
 
-        parse_response_urls(get(PATH, params))
+        get(PATH, params)
       end
 
       def self.find(showing_id, params = {})

--- a/lib/kudago_client/requests/news_request.rb
+++ b/lib/kudago_client/requests/news_request.rb
@@ -11,7 +11,7 @@ module KudagoClient
         params.slice!(:lang, :page, :page_size, :fields, :expand, :order_by, :text_format, :ids, :tags,
           :location, :place_id, :actual_only)
 
-        parse_response_urls(get(PATH, params))
+        get(PATH, params)
       end
 
       def self.find(news_id, params = {})
@@ -21,7 +21,7 @@ module KudagoClient
 
       def self.comments(news_id, params = {})
         params.slice!(:lang, :page, :page_size, :fields, :order_by, :ids)
-        parse_response_urls(get("#{PATH}#{news_id}/comments/", params))
+        get("#{PATH}#{news_id}/comments/", params)
       end
 
       def self.comment(news_id, comment_id, params = {})

--- a/lib/kudago_client/requests/place_category_request.rb
+++ b/lib/kudago_client/requests/place_category_request.rb
@@ -9,9 +9,7 @@ module KudagoClient
 
       def self.list(params = {})
         params.slice!(:lang, :fields, :order_by)
-        res = get(PATH, params)
-
-        parse_response_urls({results: res, count: res.size})
+        get(PATH, params)
       end
 
       def self.find(place_category_id, params = {})

--- a/lib/kudago_client/requests/place_request.rb
+++ b/lib/kudago_client/requests/place_request.rb
@@ -9,10 +9,9 @@ module KudagoClient
 
       def self.list(params = {})
         params.slice!(:lang, :fields, :page, :page_size, :expand, :order_by, :text_format, :ids, :location,
-          :has_showings, :showing_since, :showing_until, :is_free, :categories, :tags, :parent_id,
-          :lon, :lat, :radius)
+          :has_showings, :showing_since, :showing_until, :is_free, :categories, :tags, :parent_id, :lon, :lat, :radius)
 
-        parse_response_urls(get(PATH, params))
+        get(PATH, params)
       end
 
       def self.find(place_id, params = {})
@@ -22,7 +21,7 @@ module KudagoClient
 
       def self.comments(place_id, params = {})
         params.slice!(:lang, :place_id, :page, :page_size, :fields, :order_by, :ids)
-        parse_response_urls(get("#{PATH}#{place_id}/comments/", params))
+        get("#{PATH}#{place_id}/comments/", params)
       end
     end
   end

--- a/lib/kudago_client/requests/role_request.rb
+++ b/lib/kudago_client/requests/role_request.rb
@@ -9,7 +9,7 @@ module KudagoClient
 
       def self.list(params = {})
         params.slice!(:lang, :fields)
-        parse_response_urls(get(PATH, params))
+        get(PATH, params)
       end
 
       def self.find(agent_id, params = {})

--- a/lib/kudago_client/requests/search_request.rb
+++ b/lib/kudago_client/requests/search_request.rb
@@ -11,7 +11,7 @@ module KudagoClient
         params.slice!(:lang, :page, :page_size, :expand, :location, :ctype, :is_free, :include_inactual, :lat, :lon, :radius)
         params[:q] = query
 
-        parse_response_urls(get(PATH, params))
+        get(PATH, params)
       end
     end
   end

--- a/lib/kudago_client/response.rb
+++ b/lib/kudago_client/response.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/hash"
+
+module KudagoClient
+  class Response
+    attr_reader :list, :data
+
+    def initialize(response_body)
+      @list = true
+
+      prepared_data =
+        if response_body.is_a? Array
+          parse_with_count(response_body)
+        elsif response_body.key? :count
+          parse_response_urls(response_body)
+        else
+          @list = false
+          response_body
+        end
+
+      @data = prepared_data
+    end
+
+    def list?
+      list
+    end
+
+    private
+
+    def parse_response_urls(res)
+      res[:next_url] = res.delete :next
+      res[:previous_url] = res.delete :previous
+
+      res
+    end
+
+    def parse_with_count(res)
+      {results: res, count: res.size}
+    end
+  end
+end

--- a/lib/kudago_client/response.rb
+++ b/lib/kudago_client/response.rb
@@ -12,7 +12,7 @@ module KudagoClient
       prepared_data =
         if response_body.is_a? Array
           parse_with_count(response_body)
-        elsif response_body.key? :count
+        elsif response_body.is_a?(Hash) && response_body.key?(:count)
           parse_response_urls(response_body)
         else
           @list = false

--- a/to_do.md
+++ b/to_do.md
@@ -1,0 +1,6 @@
+# To Do and Notes
+
+* EventOfTheDayRequest parse data very bad
+* client work with lang (params or default) very bad too
+* there are no tests :)
+* add a params parser/validator for requests


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces client-side pagination capabilities and significantly refactors API response handling for improved consistency and usability.

Key changes include:

*   **Pagination Methods**: Added `next_page` and `previous_page` methods to the client, allowing users to easily navigate through paginated lists of entities by utilizing the `next_url` and `previous_url` provided in API responses.
*   **Standardized API Response Processing**: Implemented a new `Response` class that centralizes the parsing and transformation of all API responses. This class automatically:
    *   Renames `next` and `previous` fields from the raw API response to `next_url` and `previous_url` for consistent access.
    *   Wraps API responses that are arrays into a standardized hash format, including `count` and `results` keys.
    *   Provides a consistent `data` attribute to access the processed response body across all entity and list types.
*   **Refactored Request Handling**: Simplified individual request classes by removing redundant response parsing logic, as this is now handled by the `BaseRequest` and the new `Response` class. All entity and entity list constructors now expect a `Response` object and access data via its `data` attribute.
*   **Internal Consistency**: Renamed `@next` and `@previous` attributes to `@next_url` and `@previous_url` within the `BaseList` class to align with the standardized response format.
*   **Documentation Updates**: The `README.md` has been updated to include examples for the new `next_page` and `previous_page` methods. A `to_do.md` file has also been added for development notes.
<!-- kody-pr-summary:end -->